### PR TITLE
Update models.py

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -21,6 +21,8 @@ from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.internal import statekit
 from allauth.utils import get_request_param
 
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 if not allauth_settings.SOCIALACCOUNT_ENABLED:
     raise ImproperlyConfigured(
@@ -331,6 +333,8 @@ class SocialLogin:
             self._store_token()
             return True
         except SocialAccount.DoesNotExist:
+            return False
+        except User.DoesNotExist:
             return False
 
     def _store_token(self) -> None:


### PR DESCRIPTION
generalizing the solution to handle non-social accounts.

For example, if a user tries to log in with a Google account and the user does not have an account, the User.DoesNotExists exception is raised.

# 🛑 Stop

The project has been moved to https://codeberg.org/allauth/django-allauth.
Please submit your pull request there.
